### PR TITLE
Reliable rollover

### DIFF
--- a/src/enet_channel_srv.erl
+++ b/src/enet_channel_srv.erl
@@ -215,15 +215,15 @@ maybe_wrap(Seq) ->
 
 wrapped_sort(List) ->
     % Keysort while preserving order through 16-bit integer wrapping.
-    F = fun({A,_},{B,_}) ->
-            Compare = B - A,
-            if
-                Compare > 0, Compare =< ?ENET_MAX_SEQ_INDEX/2 ->
-                    true;
-                Compare < 0, Compare =< -?ENET_MAX_SEQ_INDEX/2 ->
-                    true;
-                true ->
-                    false
-            end
-        end,
-    lists:sort(F,List).
+    F = fun({A, _}, {B, _}) ->
+        Compare = B - A,
+        if
+            Compare > 0, Compare =< ?ENET_MAX_SEQ_INDEX / 2 ->
+                true;
+            Compare < 0, Compare =< -?ENET_MAX_SEQ_INDEX / 2 ->
+                true;
+            true ->
+                false
+        end
+    end,
+    lists:sort(F, List).


### PR DESCRIPTION
This patch is intended to prevent issues from occurring at the boundary condition where the 16-bit counter for the sequence number rolls over in the C code. The reliable packet window now has a custom sorting function applied to ensure that order is preserved across rollovers, for exactly one rollover. 

The channel server will now stop with reason `out_of_sync` if the window grows larger than 4096 entries. 

I had originally intended to pattern matching from the `recv_reliable` heads into an `if` so I could run the wrapping function before doing comparison in the guards, but it turns out that we're already sufficiently wrapping in the `dispatch/4` function. So the `if` here is more-or-less cosmetic. 

Fixes #2 - hopefully 😄 