### PR TITLE
Unreliable window

### DIFF
--- a/src/enet.erl
+++ b/src/enet.erl
@@ -26,7 +26,7 @@
     ConnectFun ::
         mfa()
         | fun((map()) -> {ok, pid()} | {error, term()}),
-    Options :: [{atom(), term()}]
+    Options :: [{atom(), term()}, ...]
 ) ->
     {ok, port_number()} | {error, term()}.
 

--- a/src/enet_channel_srv.erl
+++ b/src/enet_channel_srv.erl
@@ -130,7 +130,7 @@ handle_cast({recv_unreliable, {#command_header{}, C = #unreliable{sequence_numbe
             Worker ! {enet, ID, C},
             NextSeq = maybe_wrap(N+1),
             S1 = S0#state{incoming_unreliable_sequence_number = NextSeq},
-            {noreply, S1};
+            {noreply, S1}
     end;
 handle_cast({send_unreliable, Data}, S0) ->
     ID = S0#state.id,
@@ -173,7 +173,7 @@ handle_cast({recv_reliable, {#command_header{reliable_sequence_number = N}, C = 
             SortedWindow = wrapped_sort(Window),
             {NextSeq, NewWindow} = dispatch(N, SortedWindow, ID, Worker),
             S1 = S0#state{incoming_reliable_sequence_number = NextSeq, reliable_window = NewWindow},
-            {noreply, S1};
+            {noreply, S1}
     end;
 handle_cast({send_reliable, Data}, S0) ->
     ID = S0#state.id,

--- a/src/enet_channel_srv.erl
+++ b/src/enet_channel_srv.erl
@@ -37,7 +37,7 @@
     peer,
     worker,
     incoming_reliable_sequence_number = 1,
-    incoming_unreliable_sequence_number = 0,
+    incoming_unreliable_sequence_number = 1,
     outgoing_reliable_sequence_number = 1,
     outgoing_unreliable_sequence_number = 1,
     %% reliableWindows [ENET_PEER_RELIABLE_WINDOWS] (uint16 * 16 = 32 bytes)

--- a/src/enet_channel_srv.erl
+++ b/src/enet_channel_srv.erl
@@ -116,6 +116,16 @@ handle_cast({send_unsequenced, Data}, S0) ->
 handle_cast({recv_unreliable, {#command_header{}, C = #unreliable{sequence_number = N}}}, S0) ->
     Expected = S0#state.incoming_unreliable_sequence_number,
     if
+        N =:= Expected ->
+            Worker = S0#state.worker,
+            ID = S0#state.id,
+            Worker ! {enet, ID, C},
+            % Dispatch any buffered packets
+            Window = S0#state.unreliable_window,
+            SortedWindow = wrapped_sort(Window),
+            {NextSeq, NewWindow} = unreliable_dispatch(N, SortedWindow, ID, Worker),
+            S1 = S0#state{incoming_unreliable_sequence_number = NextSeq, unreliable_window = NewWindow},
+            {noreply, S1};
         % The guard is a bit complex because we need to account for wrapped
         % sequence numbers. Examples:
         % N = 5, Expected = 4. -> 5-4 = 1.
@@ -133,16 +143,9 @@ handle_cast({recv_unreliable, {#command_header{}, C = #unreliable{sequence_numbe
             %% Data is old - drop it and continue.
             logger:debug("Discard outdated packet. Recv: ~p. Expect: ~p", [N, Expected]),
             {noreply, S0};
+        % We should crash if no conditions are satisfied
         true ->
-            Worker = S0#state.worker,
-            ID = S0#state.id,
-            Worker ! {enet, ID, C},
-            % Dispatch any buffered packets
-            Window = S0#state.unreliable_window,
-            SortedWindow = wrapped_sort(Window),
-            {NextSeq, NewWindow} = unreliable_dispatch(N, SortedWindow, ID, Worker),
-            S1 = S0#state{incoming_unreliable_sequence_number = NextSeq, unreliable_window = NewWindow},
-            {noreply, S1}
+            {stop, unexpected}
     end;
 handle_cast({send_unreliable, Data}, S0) ->
     ID = S0#state.id,
@@ -159,6 +162,17 @@ handle_cast({recv_reliable, _Data}, S0 = #state{reliable_window = W}) when
 handle_cast({recv_reliable, {#command_header{reliable_sequence_number = N}, C = #reliable{}}}, S0) ->
     Expected = S0#state.incoming_reliable_sequence_number,
     if
+        N =:= Expected ->
+            ID = S0#state.id,
+            % Dispatch this packet
+            Worker = S0#state.worker,
+            Worker ! {enet, ID, C},
+            % Dispatch any buffered packets
+            Window = S0#state.reliable_window,
+            SortedWindow = wrapped_sort(Window),
+            {NextSeq, NewWindow} = reliable_dispatch(N, SortedWindow, ID, Worker),
+            S1 = S0#state{incoming_reliable_sequence_number = NextSeq, reliable_window = NewWindow},
+            {noreply, S1};
         % The guard is a bit complex because we need to account for wrapped
         % sequence numbers. Examples:
         % N = 5, Expected = 4. -> 5-4 = 1.
@@ -174,17 +188,9 @@ handle_cast({recv_reliable, {#command_header{reliable_sequence_number = N}, C = 
         N < Expected; N - Expected >= ?ENET_MAX_SEQ_INDEX/2  ->
             logger:debug("Discard outdated packet. Recv: ~p. Expect: ~p", [N, Expected]),
             {noreply, S0};
+        % We should crash if no conditions are satisfied
         true ->
-            ID = S0#state.id,
-            % Dispatch this packet
-            Worker = S0#state.worker,
-            Worker ! {enet, ID, C},
-            % Dispatch any buffered packets
-            Window = S0#state.reliable_window,
-            SortedWindow = wrapped_sort(Window),
-            {NextSeq, NewWindow} = reliable_dispatch(N, SortedWindow, ID, Worker),
-            S1 = S0#state{incoming_reliable_sequence_number = NextSeq, reliable_window = NewWindow},
-            {noreply, S1}
+            {stop, unexpected}
     end;
 handle_cast({send_reliable, Data}, S0) ->
     ID = S0#state.id,

--- a/src/enet_peer.erl
+++ b/src/enet_peer.erl
@@ -291,6 +291,7 @@ connecting(cast, {incoming_command, {H, C = #acknowledge{}}}, S) ->
     CanceledTimeout = cancel_resend_timer(ChannelID, SentTime, SequenceNumber),
     {next_state, acknowledging_verify_connect, S, [CanceledTimeout]};
 connecting({timeout, {_ChannelID, _SentTime, _SequenceNumber}}, _, S) ->
+    logger:debug("connection timeout"),
     {stop, timeout, S};
 connecting(EventType, EventContent, S) ->
     handle_event(EventType, EventContent, S).
@@ -372,6 +373,7 @@ acknowledging_connect(cast, {incoming_command, {_H, C = #connect{}}}, S) ->
     },
     {next_state, verifying_connect, NewS, [VerifyConnectTimeout]};
 acknowledging_connect({timeout, {_ChannelID, _SentTime, _SequenceNr}}, _, S) ->
+    logger:debug("acknoledgment timeout"),
     {stop, timeout, S};
 acknowledging_connect(EventType, EventContent, S) ->
     handle_event(EventType, EventContent, S).
@@ -759,6 +761,7 @@ connected({timeout, recv}, ping, S) ->
     %%
     %% - Stop
     %%
+    logger:debug("ping timeout"),
     {stop, timeout, S};
 connected({timeout, send}, ping, S) ->
     %%


### PR DESCRIPTION
This patch improves the reliable/unreliable windows to account for the possibility of a wrapping uint16 in the C version of ENet. The guard assumes that the wrap will only happen once for this channel. At a packet rate of 100Hz the window will wrap in something like 10 minutes, so that seems at least an order of magnitude longer than it would take for a connection to time out by other means. 