### PR TITLE
Decompress

### DIFF
--- a/src/enet_host.erl
+++ b/src/enet_host.erl
@@ -101,7 +101,7 @@ init({AssignedPort, ConnectFun, Options}) ->
         end,
     Compression = 
         case lists:keyfind(compression_mode, 1, Options) of
-            {compression, CompressionMode} -> CompressionMode;
+            {compression_mode, CompressionMode} -> CompressionMode;
             false -> none
         end,
     true = gproc:mreg(

--- a/src/enet_host.erl
+++ b/src/enet_host.erl
@@ -212,6 +212,10 @@ handle_info({udp, Socket, IP, Port, Packet}, S) ->
             sent_time = SentTime
         },
         Rest} = enet_protocol_decode:protocol_header(Packet),
+    % A bit hackish - assume ZLIB for now
+    Decompress = fun(Packet) -> 
+                         zlib:gunzip(Packet)
+                 end,
     Commands =
         case IsCompressed of
             0 -> Rest;

--- a/src/enet_host.erl
+++ b/src/enet_host.erl
@@ -295,15 +295,12 @@ start_peer(Peer = #enet_peer{name = Ref}) ->
     {ok, Pid}.
 
 decompress(Data, zlib) -> 
-    Z = zlib:open(),
-    % TODO: Replace with Safe Inflate?
-    zlib:inflate(Z,Data);
+    zlib:uncompress(Data);
 decompress(_Data, Mode) ->
     unsupported_compress_mode(Mode).
 
 compress(Data, zlib) ->
-    Z = zlib:open(),
-    zlib:deflate(Z,Data);
+    zlib:compress(Data);
 compress(_Data, Mode) ->
     unsupported_compress_mode(Mode).
 


### PR DESCRIPTION
PR adds zlib compression support. 
A new configuration option is added to enet_host, compression_mode. e.g.: 

```
Options = [ {peer_limit, ?PEER_LIMIT}, {channel_limit, ?CHANNEL_LIMIT}, {compression_mode, zlib} ], 
Handler = {my_enet_handler_module, start, []}, 
enet:start_host(?ENET_PORT, Handler, Options),
``` 

This assumes that the host will use the same compression to send and receive packets. If there's a demonstrable use case we could later change it to have compress_fun and decompress_fun and have the consumer of the library supply the (de)compression functions.