### PR TITLE
Fix connect_peer and some Godot compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,20 @@ connect_peer(HostPort, IP, RemotePort, ChannelCount) -> {ok, Peer} | {error, ato
     ChannelCount = channel_count()
     Peer = pid()
 ```
-Start a new peer on the host listening on `HostPort` connecting to a remote host on address `IP:RemotePort`. The peer process will call `ConnectFun` (given to start_host/3) when the handshake has been completed successfully.
+Start a new peer on the host listening on `HostPort` connecting to a remote host on address `IP:RemotePort`. The peer process will call `ConnectFun` (given to start_host/3) when the handshake has been completed successfully. A random _uint32_ integer will be sent as **peer_id** in enet `CONNECT` packet 'Data' field, as required by Godot.
+
+#### connect_peer/5
+```erlang
+connect_peer(HostPort, IP, RemotePort, ChannelCount, Data) -> {ok, Peer} | {error, atom()}
+
+    HostPort = port_number()
+    IP = string()
+    RemotePort = port_number()
+    ChannelCount = channel_count()
+    Peer = pid()
+    Data = pos_integer()
+```
+Start a new peer on the host listening on `HostPort` connecting to a remote host on address `IP:RemotePort`. The peer process will call `ConnectFun` (given to start_host/3) when the handshake has been completed successfully. 'Data' must be a _uint32_ integer that will be sent in enet `CONNECT` packet 'Data' field.
 
 #### disconnect_peer/1
 ```erlang

--- a/src/enet_command.erl
+++ b/src/enet_command.erl
@@ -5,7 +5,7 @@
 
 -export([
     acknowledge/2,
-    connect/12,
+    connect/13,
     verify_connect/8,
     sequenced_disconnect/0,
     unsequenced_disconnect/0,
@@ -23,7 +23,8 @@ acknowledge(H = #command_header{}, SentTime) ->
     {
         #command_header{
             command = ?COMMAND_ACKNOWLEDGE,
-            channel_id = ChannelID
+            channel_id = ChannelID,
+            reliable_sequence_number = N
         },
         #acknowledge{
             received_reliable_sequence_number = N,
@@ -43,7 +44,8 @@ connect(
     PacketThrottleAcceleration,
     PacketThrottleDeceleration,
     ConnectID,
-    OutgoingReliableSequenceNumber
+    OutgoingReliableSequenceNumber,
+    PacketData
 ) ->
     WindowSize = calculate_initial_window_size(OutgoingBandwidth),
     {
@@ -66,7 +68,7 @@ connect(
             packet_throttle_deceleration = PacketThrottleDeceleration,
             connect_id = ConnectID,
             %% What is this used for?
-            data = 0
+            data = PacketData
         }
     }.
 

--- a/src/enet_constants.hrl
+++ b/src/enet_constants.hrl
@@ -21,7 +21,7 @@
 -define(HOST_RECEIVE_BUFFER_SIZE          , 256 * 1024).
 -define(HOST_SEND_BUFFER_SIZE             , 256 * 1024).
 -define(HOST_BANDWIDTH_THROTTLE_INTERVAL  , 1000).
--define(HOST_DEFAULT_MTU                  , 1400).
+-define(HOST_DEFAULT_MTU                  , 1392).
 -define(HOST_DEFAULT_MAXIMUM_PACKET_SIZE  , 32 * 1024 * 1024).
 -define(HOST_DEFAULT_MAXIMUM_WAITING_DATA , 32 * 1024 * 1024).
 

--- a/src/enet_host.erl
+++ b/src/enet_host.erl
@@ -10,7 +10,7 @@
     start_link/3,
     socket_options/0,
     give_socket/2,
-    connect/4,
+    connect/5,
     send_outgoing_commands/4,
     send_outgoing_commands/5,
     get_port/1,
@@ -52,8 +52,8 @@ give_socket(Host, Socket) ->
     ok = gen_udp:controlling_process(Socket, Host),
     gen_server:cast(Host, {give_socket, Socket}).
 
-connect(Host, IP, Port, ChannelCount) ->
-    gen_server:call(Host, {connect, IP, Port, ChannelCount}).
+connect(Host, IP, Port, ChannelCount, Data) ->
+    gen_server:call(Host, {connect, IP, Port, ChannelCount, Data}).
 
 send_outgoing_commands(Host, Commands, IP, Port) ->
     send_outgoing_commands(Host, Commands, IP, Port, ?NULL_PEER_ID).
@@ -134,7 +134,7 @@ init({AssignedPort, ConnectFun, Options}) ->
                         socket = Socket}}
     end.
 
-handle_call({connect, IP, Port, Channels}, _From, S) ->
+handle_call({connect, IP, Port, Channels, Data}, _From, S) ->
     %%
     %% Connect to a remote peer.
     %%
@@ -157,7 +157,8 @@ handle_call({connect, IP, Port, Channels}, _From, S) ->
                     name = Ref,
                     host = self(),
                     channels = Channels,
-                    connect_fun = ConnectFun
+                    connect_fun = ConnectFun,
+                    connect_packet_data = Data
                 },
                 start_peer(Peer)
         catch

--- a/src/enet_peer.hrl
+++ b/src/enet_peer.hrl
@@ -7,5 +7,6 @@
          name,
          host,
          channels,
-         connect_fun
+         connect_fun,
+         connect_packet_data
         }).


### PR DESCRIPTION
### Changelog
- Send random **peer_id** in connect_peer `CONNECT` packet 'Data' field
- Match default MTU with Godot's https://github.com/godotengine/godot/blob/c6d130abd9188f313e6701d01a0ddd6ea32166a0/thirdparty/enet/enet/enet.h#L222
- Fix missing `reliable_sequence_number` in `ACKNOWLEDGE` packet header
- Pass initial `CONNECT` PacketData in Worker `peer_info` state
- Add missing handler for **#verify_connect** packets in `connecting` state. This missing function caused `connect_peer/4` to be stuck waiting for an `ACKNOWLEDGE` packet that is not sent by Godot servers
- Add temporary fix for `acknowledging_verify_connect` bandwidth negotiation step
- Add Worker message on `ping_timeout` to allow graceful shutdown
- Update Documentation